### PR TITLE
Add Dockerfile to deploy only commish-bot application

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Exclude weekly-recap app
+cmd/weekly-recap/
+
+# Exclude documentation
+docs/
+*.md
+
+# Exclude development files
+.git/
+.github/
+scripts/
+testutil/
+tools/
+
+# Exclude test files
+*_test.go
+**/*_test.go
+
+# Exclude build artifacts
+*.log
+.env
+.env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Dockerfile for Discord Bot (commish-bot)
+FROM golang:1.21-alpine AS builder
+
+WORKDIR /app
+
+# Copy go mod files
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build only the commish-bot application
+RUN CGO_ENABLED=0 GOOS=linux go build -o commish-bot ./cmd/commish-bot
+
+# Use a minimal base image
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+
+# Copy the binary from builder stage
+COPY --from=builder /app/commish-bot .
+
+# Cloud Run requires the app to listen on PORT env var
+ENV PORT=8080
+
+CMD ["./commish-bot"]


### PR DESCRIPTION
- Create Dockerfile that builds only cmd/commish-bot (not weekly-recap)
- Add .dockerignore to exclude unnecessary files and weekly-recap app
- Ensures Cloud Run deploys only the Discord bot, not the weekly recap tool

Fixes deployment error where Cloud Run was trying to run wrong application.

🤖 Generated with [Claude Code](https://claude.ai/code)